### PR TITLE
Add exclude spirit seed setting based on existing sun kissed bone feature

### DIFF
--- a/src/main/java/com/camjewell/MokhaLootTrackerConfig.java
+++ b/src/main/java/com/camjewell/MokhaLootTrackerConfig.java
@@ -7,7 +7,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("mokhaloot")
 public interface MokhaLootTrackerConfig extends Config {
 
-	@ConfigItem(keyName = "minItemValueThreshold", name = "Exclude Items Under Value", description = "Items individually valued under this amount will be excluded from wave value and item lists. Set to 0 to show all items. The panel will show both filtered and full values.", position = 3)
+	@ConfigItem(keyName = "minItemValueThreshold", name = "Exclude Items Under Value", description = "Items individually valued under this amount will be excluded from wave value and item lists. Set to 0 to show all items. The panel will show both filtered and full values.", position = 4)
 	default int minItemValueThreshold() {
 		return 0;
 	}
@@ -27,7 +27,12 @@ public interface MokhaLootTrackerConfig extends Config {
 		return true;
 	}
 
-	@ConfigItem(keyName = "showSuppliesUsedBeta", name = "Show Supplies Used (beta)", description = "Enable supplies-used summary and item breakdown. Beta feature: tracking still occurs even when disabled.", position = 4)
+	@ConfigItem(keyName = "excludeSpiritSeedValue", name = "Exclude Spirit Seeds Value", description = "Exclude Spirit Seeds value from loot tracking. If enabled, seeds are not counted in lost/claimed values.", position = 3)
+	default boolean excludeSpiritSeedValue() {
+		return false;
+	}
+
+	@ConfigItem(keyName = "showSuppliesUsedBeta", name = "Show Supplies Used (beta)", description = "Enable supplies-used summary and item breakdown. Beta feature: tracking still occurs even when disabled.", position = 5)
 	default boolean showSuppliesUsedBeta() {
 		return false;
 	}

--- a/src/main/java/com/camjewell/MokhaLootTrackerPlugin.java
+++ b/src/main/java/com/camjewell/MokhaLootTrackerPlugin.java
@@ -56,6 +56,10 @@ public class MokhaLootTrackerPlugin extends Plugin {
 
     private static final int SUN_KISSED_BONES_ID = 29378;
     private static final int SUN_KISSED_BONES_VALUE = 8000;
+
+    private static final int SPIRIT_SEEDS_ID = 5317;
+    private static final int SPIRIT_SEED_VALUE = 140000;
+
     private static final String CONFIG_KEY_TOTAL_LOST = "totalLostValue";
     private static final String CONFIG_KEY_TIMES_DIED = "timesDied";
     private static final String CONFIG_KEY_DEATH_COSTS = "totalDeathCosts";
@@ -285,6 +289,7 @@ public class MokhaLootTrackerPlugin extends Plugin {
         if (configChanged.getGroup().equals("mokhaloot")) {
             if (configChanged.getKey().equals("excludeSunKissedBonesValue") ||
                     configChanged.getKey().equals("minItemValueThreshold") ||
+                    configChanged.getKey().equals("excludeSpiritSeedsValue") ||
                     configChanged.getKey().equals("showSuppliesUsedBeta")) {
                 // Refresh panel when display-related settings change
                 clientThread.invokeLater(() -> panel.updateStats());
@@ -1120,9 +1125,9 @@ public class MokhaLootTrackerPlugin extends Plugin {
         return 0;
     }
 
-    // Calculate loot value with optional Sun-kissed Bones exclusion
+    // Calculate loot value with optional Sun-kissed Bones or Spirit Seeds exclusion
     private long getAdjustedLootValue(long baseValue, List<LootItem> items) {
-        boolean excludeEnabled = config.excludeSunKissedBonesValue();
+        boolean excludeEnabled = config.excludeSunKissedBonesValue() || config.excludeSpiritSeedValue();
 
         if (!excludeEnabled) {
             return baseValue;
@@ -1134,9 +1139,11 @@ public class MokhaLootTrackerPlugin extends Plugin {
 
         long adjustment = 0;
         for (LootItem item : items) {
-            if (item.getId() == SUN_KISSED_BONES_ID) {
-                adjustment = (long) item.getQuantity() * SUN_KISSED_BONES_VALUE;
-                break;
+            if (item.getId() == SUN_KISSED_BONES_ID && config.excludeSunKissedBonesValue()) {
+                adjustment += (long) item.getQuantity() * SUN_KISSED_BONES_VALUE;
+            }
+            if (item.getId() == SPIRIT_SEEDS_ID && config.excludeSpiritSeedValue()) {
+                adjustment += (long) item.getQuantity() * SPIRIT_SEED_VALUE;
             }
         }
 


### PR DESCRIPTION
## Justification

I don't bother turning in spirit seeds, so I'd like to ignore them from the loot total.

## Details

I've copied the existing setting to exclude sun kissed bones, replacing the IDs/values etc.

I added it below the bones setting in the config menu, and updated the other positions.